### PR TITLE
Following better naming conventions for the generated files

### DIFF
--- a/imageGrid/imageGrid.py
+++ b/imageGrid/imageGrid.py
@@ -129,9 +129,11 @@ def saveGrid(image_fn, div_x, div_y):
     # for k, p in enumerate(cropFromTL(img, div_x, div_y)):
     for k, p in enumerate(cropSquare(img, div_x)):
         # print(k,p)
+        numOfImages = div_x * div_y
+        widthOfNumber = len(str(numOfImages))
         img = Image.new('RGB', (crop_w,crop_h), 255)
         img.paste(p)
-        fn = folder / 'grid-{}.jpg'.format(k)
+        fn = folder / '{}.jpg'.format(str(numOfImages - k).zfill(widthOfNumber))
         img.save(fn)
         images.append(fn)
     return images


### PR DESCRIPTION
There were a few problems I felt with the original way files were named.

- The top left image was actually the last image in a file browser and had the largest number
- There was not consistency in the width of the file names
- And the "grid-" prefix added clutter

To solve these issues I
- Removing the "grid-" prefix
- Add leading 0s so all filenames have equal width using zfill
- The first image, the top left corner, is now 01

These changes make the images easier to view in a file explorer and allow them to be interpreted easier by other